### PR TITLE
Fixes

### DIFF
--- a/bin.js
+++ b/bin.js
@@ -1,7 +1,6 @@
 #!/usr/bin/env node
 
-var sys = require("sys"),
-    replicate = require("./main");
+var replicate = require("./main");
 
 var args = process.argv.slice(0);
 
@@ -11,3 +10,4 @@ args.shift(); args.shift();
 if(args.length < 2) throw "syntax: replicate http://admin:pass@somecouch/sourcedb http://admin:pass@somecouch/destinationdb"
 
 replicate(args[0], args[1], function(results) {console.log('replication complete')});
+

--- a/package.json
+++ b/package.json
@@ -9,9 +9,14 @@
   },
   "main": "main.js",
   "engines": {
-    "node": "~v0.5.4-pre"
+    "node": ">= 0.5"
   },
-  "dependencies": {"request":">= 2.0.5"},
+  "dependencies": {
+    "request":">= 2.1.x",
+    "follow":"0.1.x",
+    "formidable": "1.0.x"
+  },
   "devDependencies": {},
   "bin" : { "replicate" : "./bin.js" }
 }
+

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "main": "main.js",
   "engines": {
-    "node": ">= 0.5"
+    "node": ">= 0.4"
   },
   "dependencies": {
     "request":">= 2.1.x",


### PR DESCRIPTION
Make replicate installable by changing node version from `~v0.5.4-pre` to `>= v0.5` and adding all dependencies to `package.json`.

Remove unused `sys` require.

Fixes #2.
